### PR TITLE
Remove console.log in test case

### DIFF
--- a/test/integration/api.integration.test.js
+++ b/test/integration/api.integration.test.js
@@ -297,7 +297,6 @@ data.forEach(testdata => {
         const res = await api.sendTransaction(transaction)
         expect(res).toBeDefined()
         expect(res.txId).toBeDefined()
-        console.log(`Broadcasted ${api.coin} ${api.network}: ${res.txId}`)
       })
     })
   })


### PR DESCRIPTION
Removing this since our test cases shouldn't print console logs outside of debugging