### PR TITLE
Cache in travis using NPM not Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ script:
   - npm run lint
   - npm test -- --coverage
 cache:
-  - yarn
+  - npm
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
We use NPM for dependency management, not Yarn, so updating Travis's cache to reflect this.